### PR TITLE
Log raw graphql responses when they don't unmarshal correctly

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -38,6 +38,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -141,7 +142,9 @@ func (c *Client) runWithJSON(ctx context.Context, req *Request, resp interface{}
 		if res.StatusCode != http.StatusOK {
 			return fmt.Errorf("server returned a non-200 status code: %v", res.StatusCode)
 		}
-		return errors.Wrap(err, "decoding response")
+		sep := " | "
+		indentedBody := sep + strings.Join(strings.Split(strings.Trim(buf.String(), " \n\t\r"), "\n"), "\n"+sep)
+		return fmt.Errorf("decoding response:\n%s\nerror: %w", indentedBody, err)
 	}
 	if len(gr.Errors) > 0 {
 		// return first error

--- a/graphql.go
+++ b/graphql.go
@@ -142,8 +142,14 @@ func (c *Client) runWithJSON(ctx context.Context, req *Request, resp interface{}
 		if res.StatusCode != http.StatusOK {
 			return fmt.Errorf("server returned a non-200 status code: %v", res.StatusCode)
 		}
+		var indentedBodyBuffer bytes.Buffer
+		var indentedBody string
 		sep := " | "
-		indentedBody := sep + strings.Join(strings.Split(strings.Trim(buf.String(), " \n\t\r"), "\n"), "\n"+sep)
+		if err := json.Indent(&indentedBodyBuffer, buf.Bytes(), sep, "  "); err != nil {
+			indentedBody = sep + strings.Join(strings.Split(strings.Trim(buf.String(), " \n\t\r"), "\n"), "\n"+sep)
+		} else {
+			indentedBody = sep + indentedBodyBuffer.String()
+		}
 		return fmt.Errorf("decoding response:\n%s\nerror: %w", indentedBody, err)
 	}
 	if len(gr.Errors) > 0 {


### PR DESCRIPTION
When the json output doesn't match the struct layout, it prints the raw json response in the error for debugging reasons.

The response pretty-prints and indents the json with a pipe symbol, it looks something like this:
```
Error: decoding response
 | {
 |     "error": "some error string",
 |     "code": 10,
 | }
error: json: cannot unmarshal object into Go struct field [xyz] of type [jkl]
```

(it used to be `Error: decoding response: json: cannot unmarshal object into Go struct field[xyz] of type [jkl]`)

Relevant context: https://github.com/superfly/flyctl/issues/1866