### PR TITLE
Return the response in the error, when http response is anything other than 200 OK.

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -134,7 +134,10 @@ func (c *Client) runWithJSON(ctx context.Context, req *Request, resp interface{}
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("server returned a non-200 status code: %v", res.StatusCode)
+		return &HttpError{
+			err:      fmt.Errorf("server returned a non-200 status code: %v", res.StatusCode),
+			Response: res,
+		}
 	}
 	var buf bytes.Buffer
 	if _, err := io.Copy(&buf, res.Body); err != nil {
@@ -315,6 +318,15 @@ type File struct {
 	Field string
 	Name  string
 	R     io.Reader
+}
+
+type HttpError struct {
+	err      error
+	Response *http.Response
+}
+
+func (e *HttpError) Error() string {
+	return e.err.Error()
 }
 
 type GraphQLError struct {


### PR DESCRIPTION
this enables callers to take different actions based on things like response status code, headers, body.
