### PR TITLE
Support path indices in GraphQLError.Path

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -320,7 +320,7 @@ type File struct {
 type GraphQLError struct {
 	err        error
 	Message    string
-	Path       []string
+	Path       []interface{}
 	Extensions GraphQLErrorExtensions
 }
 


### PR DESCRIPTION
Fixes the following error in `flyctl`:

```
Error: decoding response: json: cannot unmarshal number into Go struct field GraphQLError.Errors.Path of type string
```