### PR TITLE
feat: GraphQLError errors.Unwrap compatibility

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -353,6 +353,10 @@ func (gqlErr *GraphQLError) Error() string {
 	}
 }
 
+func (gqlErr *GraphQLError) Unwrap() error {
+	return gqlErr.err
+}
+
 func IsClientError(err error) bool {
 	gqlErr, ok := err.(*GraphQLError)
 	return ok && gqlErr.err != nil && len(gqlErr.Extensions.Code) == 0


### PR DESCRIPTION
The code below doesn't work as GraphQLError doesn't implement `Unwrap() error` method.
```go
if errors.Is(err, context.DeadlineExceeded) { // ... // }
```

This results in awkward code check
```go
func IsGQLTimeout(err error) bool {
	var gqlErr *graphql.GraphQLError
	return errors.As(err, &gqlErr) && strings.Contains(gqlErr.Error(), "context deadline exceeded")
}
```

I see that inner err is kept private, to avoid exposing it, this is a potential way to make it compatible.